### PR TITLE
New Check Added

### DIFF
--- a/client/wagons.lua
+++ b/client/wagons.lua
@@ -14,13 +14,15 @@ if Config.Wagons.active then
                     horse = Citizen.InvokeNative(0xA8BA0BAE0173457B,wagon,0)
                     -- If vehicle stopped but the horse walks = buggy wagon
                     if IsPedWalking(horse) then
-                        -- Delete driver & wagon
-                        driver = Citizen.InvokeNative(0x2963B5C1637E8A27,wagon)
-                        if driver ~= PlayerPedId() then -- Ensure the driver is not a player
-                            if driver then
-                                DeleteEntity(driver) -- Delete driver from wagon if there is one
+                        if not IsEntityAMissionEntity(wagon) then --if the wagon is not a mission entity. Peds spawned naturally by game return false, peds created by script return true by default preventing this from deleting entities intentionally spawned by scripts
+                            -- Delete driver & wagon
+                            driver = Citizen.InvokeNative(0x2963B5C1637E8A27,wagon)
+                            if driver ~= PlayerPedId() then -- Ensure the driver is not a player
+                                if driver then
+                                    DeleteEntity(driver) -- Delete driver from wagon if there is one
+                                end
+                                DeleteEntity(wagon) -- Delete buggy wagon
                             end
-                            DeleteEntity(wagon) -- Delete buggy wagon
                         end
                     end
                 end


### PR DESCRIPTION
Checks if the wagon is a mission entity before deleting. This prevents it despawning wagons made by scripts, as entities created by scripts return true by default while entities created by the game return false by default